### PR TITLE
Add env config for size and TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Basic Upload Server
+
+A minimal FastAPI application for uploading and sharing files. Uploaded files are stored on disk and cleaned up automatically.
+
+## Environment variables
+
+The behaviour of the server can be tweaked using the following variables:
+
+- `MAX_SIZE` - maximum allowed upload size in **bytes**. Defaults to `524288000` (500 MB).
+- `TTL_HOURS` - time in hours before uploaded files are removed. Defaults to `24`.
+
+Example usage:
+
+```bash
+MAX_SIZE=104857600 TTL_HOURS=12 uvicorn app:app
+```
+


### PR DESCRIPTION
## Summary
- configure `MAX_SIZE` and `TTL_HOURS` via environment variables with defaults
- document configuration options in new `README.md`

## Testing
- `python -m py_compile app.py cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_686737ea4b64832583693c03c411b0d1