### PR TITLE
Improve cleanup imports and logging

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -1,6 +1,9 @@
 # cleanup.py
-import os, time
+import time
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 UPLOAD_DIR = Path(__file__).parent / "uploads"
 TTL_HOURS = 24
@@ -8,5 +11,7 @@ cutoff = time.time() - TTL_HOURS * 3600
 
 for f in UPLOAD_DIR.iterdir():
     if f.is_file() and f.stat().st_mtime < cutoff:
-        try: f.unlink()
-        except: pass
+        try:
+            f.unlink()
+        except OSError as exc:
+            logger.warning("Failed to delete %s: %s", f, exc)


### PR DESCRIPTION
## Summary
- remove unused imports in `app.py` and `cleanup.py`
- split imports onto separate lines
- add logger and handle `OSError` during file cleanup
- format spacing for flake8 compliance

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686737e935ac8325ba793132e5ad5999