### PR TITLE
Make front end text professional

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ async def upload(file: UploadFile = File(...)):
             if size > MAX_SIZE:
                 await out.close()
                 dest.unlink(missing_ok=True)
-                raise HTTPException(413, "File too bloody big (limit 500 MB)")
+                raise HTTPException(413, "File exceeds size limit (max 500 MB)")
             await out.write(chunk)
 
     return {"url": f"/file/{token}", "expires": TTL_HOURS}

--- a/foldermaker.bat
+++ b/foldermaker.bat
@@ -20,7 +20,7 @@ rem ---- Touch files ----
 rem ---- Drop a one-liner into index.html so you know it worked ----
 (
     echo ^<!DOCTYPE html^>
-    echo ^<html^>^<head^>^<title^>fuckass uploader^</title^>^</head^>
+    echo ^<html^>^<head^>^<title^>File Uploader^</title^>^</head^>
     echo ^<body^>^<h1^>It works &#x1F389;^</h1^>^</body^>
     echo ^</html^>
 ) > "%ROOT%\static\index.html"

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Drop your shit here</title>
+<title>Simple File Uploader</title>
 <style>
   body{font-family:sans-serif;display:flex;justify-content:center;align-items:center;
        height:100vh;margin:0;background:#18181b;color:#fafafa}
@@ -40,7 +40,7 @@ input.addEventListener('change', ev => handleFile(ev.target.files[0]));
 function handleFile(file){
   if(!file) return;
   if(file.size > 500*1024*1024){
-    alert("Too big, fucker (max 500 MB)."); return;
+    alert("File exceeds the 500 MB limit."); return;
   }
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/upload');


### PR DESCRIPTION
## Summary
- clean up vulgar phrases in the HTML interface and batch script
- use a professional error message in `app.py`

## Testing
- `python3 -m py_compile app.py cleanup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686737e8a9b8832585da49f317840b89