### PR TITLE
Add requirements and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Basic Upload Server
+
+This is a minimal FastAPI application that accepts large file uploads (up to 500 MB) and serves them back via a generated download link. Old uploads are automatically cleaned up.
+
+## Requirements
+
+Install dependencies with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Launch the server with `uvicorn`:
+
+```bash
+uvicorn app:app --reload
+```
+
+The frontend is available at `http://localhost:8000/` after starting the server.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+aiofiles


### PR DESCRIPTION
## Summary
- document basic usage in README
- add `requirements.txt` with FastAPI dependencies

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686737e6df548325a893ef4b1d54fd26